### PR TITLE
Generalized tables for layer land use

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ This repository maintains instructions and configuration files necessary for run
 
 ## Software requirements
 
-- Postgres 11
-- PostGIS 3.1
-- tegola v0.14.0+
+- [Postgres 11](https://www.postgresql.org/)
+- [PostGIS 3.1](https://postgis.net/)
+- [tegola v0.14.0+](https://github.com/go-spatial/tegola/releases)
 
+## Repository layouot
+
+* [tegola/](tegola/): contains the tegola config file and associated instructions.
+* [sql/](sql/): The primay SQL functions that must be installed in the database. These functions are used by tegola for fetching geometries from Postgres.
+* [etl/](etl): Instructions for running the extract, transform and load pipeline to populate the database with map data.

--- a/etl/README.md
+++ b/etl/README.md
@@ -17,10 +17,46 @@ The database also requires additional supporting functions:
 
 - `extract_names`: contained in the `./sql/helpers.sql` file.
 - `labelgrid`: This is contained in the [postgis-vt-util](https://github.com/mapbox/postgis-vt-util) package.
+- `bail`: an error reporting function contained in the `./sql/helpers.sql` file.
+- `to_int`: a type conversion function contained in the `./sql/helpers.sql` file.
+- `get_label_name`: contained in the `./sql/helpers.sql` file.
 
 ## OSM
 
-TODO: discuss the OSM data ETL process.
+The initial OSM import process has several steps:
+
+* Download a PBF extract from [https://download.geofabrik.de](https://download.geofabrik.de)
+* Run [imposm3](https://github.com/omniscale/imposm3) against the PBF extract to import the data into PostGIS.
+
+Imposm3 uses a config file in the following format:
+
+```json
+{
+    "cachedir": "/root/kartosm/cache",
+    "diffdir": "/root/kartosm/diff",
+    "expiretiles_dir": "/root/kartosm/expiretiles",
+    "expiretiles_zoom": 15,
+    "connection": "postgis: user=user password=password dbname=osm host=host prefix=NONE",
+    "mapping": "/root/wiki-repos/kartodock/workspace/mapping.yml",
+    "replication_url": "https://planet.openstreetmap.org/replication/minute/"
+}
+```
+
+Adjust the parameters to match the environment. 
+
+The following imposm command is an "end to end" run. It will perform the following:
+
+* read the OSM extract PBF `europe-latest.osm.pbf` (`-read` flag)
+* prepare a diff directory for future imports (`-diff` flag)
+* connect to the database using the `connection` string defined in the `config.europe.json` file. (`-write` flag)
+* import the data to the `import` schema using the `mapping` file defined in the `config.europe.json` file.
+* copy the data to the `public` schema (`-deployproduction` flag)
+
+```console
+$ imposm import -config config.europe.json -overwritecache -read europe-latest.osm.pbf -diff -write -deployproduction
+```
+
+This process is long, so after you start the job make sure to have a nice movie queued up to pass the time.
 
 ## OSM water
 
@@ -40,9 +76,14 @@ $ unzip water-polygons-split-3857.zip
 $ shp2pgsql -I -c -s 3857 -g way water-polygons-split-3857/water_polygons.shp water_polygons | psql -h ${PGHOST} -U ${PGUSER} -d ${PGDATABASE}
 ```
 
+And the simplified water polygons:
 
 ```console
 $ curl -O https://osmdata.openstreetmap.de/download/simplified-water-polygons-split-3857.zip
 $ unzip simplified-water-polygons-split-3857.zip
-$ shp2pgsql -I -c -s 3857 -g way simplified-water-polygons-split-3857/simplified_water_polygons.shp simplified_water_polygons | psql -h ${PGHOST} -U ${PGUSER} -d ${PGDATABASE}
+$ shp2pgsql -I -c -s 3857 -g way simplified-water-polygons-split-3857/simplified_water_polygons.shp water_polygons_simplified | psql -h ${PGHOST} -U ${PGUSER} -d ${PGDATABASE}
 ```
+
+## Create additional indexes
+
+Once the aforementioned steps are run the `create_indexes.sql` file should be run to build up additional indexes necessary for performance.

--- a/etl/create_indexes.sql
+++ b/etl/create_indexes.sql
@@ -4,10 +4,16 @@ BEGIN;
 	CREATE INDEX ON admin (maritime);
 	CREATE INDEX ON admin (admin_level);
 
+	-- layer_landuse (need to add generalized tables as well)
+	--CREATE INDEX ON planet_osm_polygon_landuse(landuse)
+
 	-- layer_place_label
 	CREATE INDEX ON planet_osm_point (name);
 	CREATE INDEX ON planet_osm_point (place);
 	CREATE INDEX ON planet_osm_point (population);
+
+	-- layer_transportation_name
+	CREATE INDEX ON planet_osm_line(highway);
 
 	-- layer_water
 	CREATE INDEX ON planet_osm_polygon (landuse);
@@ -16,5 +22,6 @@ BEGIN;
 
 	-- layer_waterway
 	CREATE INDEX ON planet_osm_line (waterway);
-	CREATE INDEX ON planet_osm_polygon (natural);
+	CREATE INDEX ON planet_osm_polygon ("natural");
+
 COMMIT;

--- a/etl/imposm_mapping.yml
+++ b/etl/imposm_mapping.yml
@@ -1,0 +1,370 @@
+areas:
+  area_tags: [buildings, landuse, leisure, natural, aeroway, amenity]
+  linear_tags: [highway, barrier, boundary]
+
+tags:
+  load_all: true
+  exclude: [note, "note:*", source, source_ref, "source:*", attribution, comment, fixme, created_by, odbl, "odbl:note", "SK53_bulk:load",  "tiger:*",  "NHD:*", "nhd:*",  "gnis:*",  "geobase:*", "accuracy:meters", "sub_sea:type", "waterway:type",  "KSJ2:*", "yh:*",  "osak:*",  "kms:*",  "ngbe:*",  "naptan:*",  "CLC:*",  "3dshapes:ggmodelk", AND_nosr_r, import, "it:fvg:*"]
+
+generalized_tables:
+  planet_osm_polygon_landuse_gen_z6:
+    source: planet_osm_polygon_landuse_gen_z7
+    tolerance: 2445.98490513
+    sql_filter: area>power(2445.98490513,2)
+  planet_osm_polygon_landuse_gen_z7:
+    source: planet_osm_polygon_landuse_gen_z8
+    tolerance: 1222.99245256
+    sql_filter: area>power(2445.98490513,2)
+  planet_osm_polygon_landuse_gen_z8:
+    source: planet_osm_polygon_landuse_gen_z9
+    sql_filter: area>power(2445.98490513,2)
+    tolerance: 611.496226281
+  planet_osm_polygon_landuse_gen_z9:
+    source: planet_osm_polygon_landuse_gen_z10
+    sql_filter: area>power(1222.99245256,2)
+    tolerance: 305.748113141
+  planet_osm_polygon_landuse_gen_z10:
+    source: planet_osm_polygon_landuse_gen_z11
+    sql_filter: area>power(611.496226281,2)
+    tolerance: 152.87405657
+  planet_osm_polygon_landuse_gen_z11:
+    source: planet_osm_polygon_landuse_gen_z12
+    sql_filter: area>power(305.748113141,2)
+    tolerance: 76.4370282852
+  planet_osm_polygon_landuse_gen_z12:
+    source: planet_osm_polygon_landuse_gen_z13
+    sql_filter: area>power(152.87405657,2)
+    tolerance: 38.2185141426
+  planet_osm_polygon_landuse_gen_z13:
+    source: planet_osm_polygon_landuse
+    sql_filter: area>power(76.4370282852,2) AND ST_IsValid(way)
+    tolerance: 19.1092570713
+
+tables:
+  planet_osm_point:
+    type: point
+    mapping:
+      __any__: [__any__]
+    columns:
+      - name: osm_id
+        type: id
+      - key: amenity
+        name: amenity
+        type: string
+      - key: highway
+        name: highway
+        type: string
+      - key: name
+        name: name
+        type: string
+      - key: place
+        name: place
+        type: string
+      - key: population
+        name: population
+        type: string
+      - key: public_transport
+        name: public_transport
+        type: string
+      - key: railway
+        name: railway
+        type: string
+      - key: tags
+        name: tags
+        type: hstore_tags
+      - name: way
+        type: validated_geometry
+
+  planet_osm_polygon:
+    type: polygon
+    mapping:
+      __any__: [__any__]
+    columns:
+      - name: osm_id
+        type: id
+      - key: aeroway
+        name: aeroway
+        type: string
+      - key: amenity
+        name: amenity
+        type: string
+      - key: area
+        name: area
+        type: string
+      - key: building
+        name: building
+        type: string
+      - key: boundary
+        name: boundary
+        type: string
+      - key: highway
+        name: highway
+        type: string
+      - key: landuse
+        name: landuse
+        type: string
+      - key: leisure
+        name: leisure
+        type: string
+      - key: name
+        name: name
+        type: string
+      - key: natural
+        name: natural
+        type: string
+      - key: public_transport
+        name: public_transport
+        type: string
+      - key: railway
+        name: railway
+        type: string
+      - key: waterway
+        name: waterway
+        type: string
+      - name: z_order
+        type: enumerate
+        args:
+          values:
+            - land
+            - island
+            - lan
+            - heath
+            - railway
+            - industrial
+            - commercial
+            - retail
+            - residential
+            - quarry
+            - zoo
+            - vineyard
+            - orchard
+            - scrub
+            - hospital
+            - place_of_worship
+            - theatre
+            - cinema
+            - nature_reserve
+            - parking
+            - fuel
+            - baracks
+            - library
+            - college
+            - school
+            - university
+            - golf_course
+            - allotments
+            - common
+            - pitch
+            - sports_centre
+            - garden
+            - recreation_ground
+            - village_green
+            - wetland
+            - grass
+            - meadow
+            - wood
+            - farmland
+            - farm
+            - farmyard
+            - cemetery
+            - forest
+            - park
+            - playground
+            - footway
+            - pedestrian
+            - water
+      - key: way_area
+        name: way_area
+        type: area
+      - key: tags
+        name: tags
+        type: hstore_tags
+      - name: way
+        type: validated_geometry
+
+  planet_osm_polygon_landuse:
+    type: polygon
+    columns:
+      - name: osm_id
+        type: id
+      - key: aeroway
+        name: aeroway
+        type: string
+      - key: amenity
+        name: amenity
+        type: string
+      - key: area
+        name: area
+        type: area
+      - key: boundary
+        name: boundary
+        type: string
+      - key: landuse
+        name: landuse
+        type: string
+      - key: leisure
+        name: leisure
+        type: string
+      - key: name
+        name: name
+        type: string
+      - key: natural
+        name: natural
+        type: string
+      - name: z_order
+        type: enumerate
+        args:
+          values:
+            - land
+            - island
+            - lan
+            - heath
+            - railway
+            - industrial
+            - commercial
+            - retail
+            - residential
+            - quarry
+            - zoo
+            - vineyard
+            - orchard
+            - scrub
+            - hospital
+            - place_of_worship
+            - theatre
+            - cinema
+            - nature_reserve
+            - parking
+            - fuel
+            - baracks
+            - library
+            - college
+            - school
+            - university
+            - golf_course
+            - allotments
+            - common
+            - pitch
+            - sports_centre
+            - garden
+            - recreation_ground
+            - village_green
+            - wetland
+            - grass
+            - meadow
+            - wood
+            - farmland
+            - farm
+            - farmyard
+            - cemetery
+            - forest
+            - park
+            - playground
+            - footway
+            - pedestrian
+            - water
+      - name: way
+        type: validated_geometry
+    mapping:
+      natural:
+      - wood
+      leisure:
+      - national_reserve
+      - nature_reserve
+      - golf_course
+      - park
+      - playground
+      #aeroway:
+      landuse:
+      - wood
+      - forest
+      - cemetery
+      - industrial
+      - village_green
+      amenity:
+      - school
+      - university
+      - hospital
+      boundary:
+      - national_park
+
+  planet_osm_line:
+    type: linestring
+    mapping:
+      __any__: [__any__]
+    columns:
+      - name: osm_id
+        type: id
+      - key: tags
+        name: tags
+        type: hstore_tags
+      - name: way
+        type: validated_geometry
+      - key: aeroway
+        name: aeroway
+        type: string
+      - key: access
+        name: access
+        type: string
+      - key: bridge
+        name: bridge
+        type: string
+      - key: highway
+        name: highway
+        type: string
+      - key: name
+        name: name
+        type: string
+      - key: railway
+        name: railway
+        type: string
+      - key: ref
+        name: ref
+        type: string
+      - key: tunnel
+        name: tunnel
+        type: string
+      - key: waterway
+        name: waterway
+        type: string
+      - key: z_order
+        name: z_order
+        type: wayzorder
+
+  admin:
+    type: relation_member
+    mapping:
+      __any__: [__any__]
+    columns:
+      - name: relation_id
+        type: id
+      - name: osm_id
+        type: id
+        from_member: true
+      - name: way
+        type: validated_geometry
+      - key: name
+        name: name
+        type: string
+      - key: boundary
+        name: boundary
+        type: string
+      - key: admin_level
+        name: admin_level
+        type: string
+      - key: claimed_by
+        name: claimed_by
+        type: string
+      - key: disputed_by
+        name: disputed_by
+        type: string
+      - key: maritime
+        name: maritime
+        type: bool
+        from_member: true
+      - key: tags
+        name: tags
+        type: hstore_tags
+    filters:
+      require:
+        admin_level: ['2', '4']

--- a/sql/functions/helpers.sql
+++ b/sql/functions/helpers.sql
@@ -18,3 +18,35 @@ CREATE OR REPLACE FUNCTION extract_names (tags hstore)
 LANGUAGE SQL
 IMMUTABLE
 STRICT;
+
+--
+-- Safe string to int conversion, on invalid input retrns 0 instead of raising an error
+--
+CREATE OR REPLACE FUNCTION to_int(s TEXT) RETURNS INTEGER
+AS $$
+BEGIN
+    RETURN CASE WHEN s~E'^\\d+$' THEN s::INTEGER ELSE 0 END;
+END;
+$$ LANGUAGE plpgsql;
+
+--
+-- Raise an error in contexts where a return is expected
+-- msg is a format string with param1..3 as optional parameters
+-- See http://www.postgresql.org/docs/9.4/static/functions-string.html#FUNCTIONS-STRING-FORMAT for details
+--
+CREATE OR REPLACE FUNCTION bail_out(msg TEXT, param1 TEXT DEFAULT '', param2 TEXT DEFAULT '', param3 TEXT DEFAULT '') RETURNS TEXT
+AS $$
+BEGIN
+    RAISE '%', pg_catalog.format(msg, param1, param2, param3);
+END;
+$$ LANGUAGE plpgsql;
+
+--
+-- Returns processed map object name based on its name column
+--
+CREATE OR REPLACE FUNCTION get_label_name(name TEXT) RETURNS TEXT
+AS $$
+BEGIN
+    RETURN pg_catalog.regexp_replace(name, '\s*;.*$', '');
+END;
+$$ LANGUAGE plpgsql;

--- a/sql/functions/layer_landuse.sql
+++ b/sql/functions/layer_landuse.sql
@@ -20,34 +20,246 @@ AS $BODY$
       ELSE bail_out('Unexpected landuse row with osm_id=%s', osm_id::TEXT)
     END AS class,
     z_order,
-    way_area
-  FROM 
-    planet_osm_polygon
-  WHERE
-    (
+    area
+  FROM (
+    SELECT 
+      osm_id,
+      aeroway,
+      amenity,
+      area,
+      landuse,
+      leisure,
+      name,
+      boundary,
+      "natural",
+      z_order,
+      way
+    FROM 
+      planet_osm_polygon_landuse_gen_z6
+    WHERE 
+      zoom_level = 6 AND
       (
-        (
-          "natural" = 'wood' OR landuse IN ('wood', 'forest')
-          OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
-          OR boundary = 'national_park'
-        )
-        AND zoom_level >= 7
-      ) OR (
-        (
-          landuse IN ('cemetery', 'industrial', 'village_green')
-          OR (aeroway IS NOT NULL AND aeroway <> '')
-          OR leisure IN ('park', 'playground')
-          OR amenity IN ('school', 'university')
-        )
-        AND zoom_level >= 10
-      ) OR (
-        amenity = 'hospital'
-        AND zoom_level >= 12
+        "natural" = 'wood' 
+        OR landuse IN ('wood', 'forest')
+        OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
+        OR boundary = 'national_park'
       )
-    )
-    AND 
+    UNION ALL
+
+    SELECT 
+      osm_id,
+      aeroway,
+      amenity,
+      area,
+      landuse,
+      leisure,
+      name,
+      boundary,
+      "natural",
+      z_order,
+      way
+    FROM 
+      planet_osm_polygon_landuse_gen_z7
+    WHERE 
+      zoom_level = 7 AND
+      (
+        "natural" = 'wood' 
+        OR landuse IN ('wood', 'forest')
+        OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
+        OR boundary = 'national_park'
+      )
+    UNION ALL
+
+    SELECT 
+      osm_id,
+      aeroway,
+      amenity,
+      area,
+      landuse,
+      leisure,
+      name,
+      boundary,
+      "natural",
+      z_order,
+      way
+    FROM 
+      planet_osm_polygon_landuse_gen_z8
+    WHERE 
+      zoom_level = 8 AND
+      (
+        "natural" = 'wood' 
+        OR landuse IN ('wood', 'forest')
+        OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
+        OR boundary = 'national_park'
+      )
+    UNION ALL
+
+    SELECT 
+      osm_id,
+      aeroway,
+      amenity,
+      area,
+      landuse,
+      leisure,
+      name,
+      boundary,
+      "natural",
+      z_order,
+      way
+    FROM 
+      planet_osm_polygon_landuse_gen_z9
+    WHERE 
+      zoom_level = 9 AND
+      (
+        "natural" = 'wood' 
+        OR landuse IN ('wood', 'forest')
+        OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
+        OR boundary = 'national_park'
+      )
+    UNION ALL
+
+    SELECT 
+      osm_id,
+      aeroway,
+      amenity,
+      area,
+      landuse,
+      leisure,
+      name,
+      boundary,
+      "natural",
+      z_order,
+      way
+    FROM 
+      planet_osm_polygon_landuse_gen_z10
+    WHERE 
+      zoom_level = 10 AND
+      (
+        "natural" = 'wood' 
+        OR landuse IN ('wood', 'forest')
+        OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
+        OR boundary = 'national_park'
+        OR landuse IN ('cemetery', 'industrial', 'village_green')
+        OR (aeroway IS NOT NULL AND aeroway <> '')
+        OR leisure IN ('park', 'playground')
+        OR amenity IN ('school', 'university')
+      )
+    UNION ALL
+
+    SELECT 
+      osm_id,
+      aeroway,
+      amenity,
+      area,
+      landuse,
+      leisure,
+      name,
+      boundary,
+      "natural",
+      z_order,
+      way
+    FROM 
+      planet_osm_polygon_landuse_gen_z11
+    WHERE 
+      zoom_level = 11 AND
+      (
+        "natural" = 'wood' 
+        OR landuse IN ('wood', 'forest')
+        OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
+        OR boundary = 'national_park'
+        OR landuse IN ('cemetery', 'industrial', 'village_green')
+        OR (aeroway IS NOT NULL AND aeroway <> '')
+        OR leisure IN ('park', 'playground')
+        OR amenity IN ('school', 'university')
+      )
+    UNION ALL
+
+    SELECT 
+      osm_id,
+      aeroway,
+      amenity,
+      area,
+      landuse,
+      leisure,
+      name,
+      boundary,
+      "natural",
+      z_order,
+      way
+    FROM 
+      planet_osm_polygon_landuse_gen_z12
+    WHERE 
+      zoom_level = 12 AND
+      (
+        "natural" = 'wood' 
+        OR landuse IN ('wood', 'forest')
+        OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
+        OR boundary = 'national_park'
+        OR landuse IN ('cemetery', 'industrial', 'village_green')
+        OR (aeroway IS NOT NULL AND aeroway <> '')
+        OR leisure IN ('park', 'playground')
+        OR amenity IN ('school', 'university', 'hospital')
+      )
+    UNION ALL
+
+    SELECT 
+      osm_id,
+      aeroway,
+      amenity,
+      area,
+      landuse,
+      leisure,
+      name,
+      boundary,
+      "natural",
+      z_order,
+      way
+    FROM 
+      planet_osm_polygon_landuse_gen_z13
+    WHERE 
+      zoom_level = 13 AND
+      (
+        "natural" = 'wood' 
+        OR landuse IN ('wood', 'forest')
+        OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
+        OR boundary = 'national_park'
+        OR landuse IN ('cemetery', 'industrial', 'village_green')
+        OR (aeroway IS NOT NULL AND aeroway <> '')
+        OR leisure IN ('park', 'playground')
+        OR amenity IN ('school', 'university', 'hospital')
+      )
+    UNION ALL
+
+    SELECT 
+      osm_id,
+      aeroway,
+      amenity,
+      area,
+      landuse,
+      leisure,
+      name,
+      boundary,
+      "natural",
+      z_order,
+      way
+    FROM 
+      planet_osm_polygon_landuse
+    WHERE 
+      zoom_level >= 14 AND
+      (
+        "natural" = 'wood' 
+        OR landuse IN ('wood', 'forest')
+        OR leisure IN ('national_reserve', 'nature_reserve', 'golf_course')
+        OR boundary = 'national_park'
+        OR landuse IN ('cemetery', 'industrial', 'village_green')
+        OR (aeroway IS NOT NULL AND aeroway <> '')
+        OR leisure IN ('park', 'playground')
+        OR amenity IN ('school', 'university', 'hospital')
+      )
+    ) AS layer_data
+    WHERE 
       way && bbox
-    ORDER BY z_order, way_area DESC
+    ORDER BY z_order, area DESC
   ;
 $BODY$;
 

--- a/sql/functions/layer_water.sql
+++ b/sql/functions/layer_water.sql
@@ -38,7 +38,7 @@ AS $BODY$
     gid::bigint AS osm_id, 
     way
   FROM 
-    simplified_water_polygons
+    water_polygons_simplified
   WHERE
     zoom_level < 10 
     AND way && bbox

--- a/tegola/tegola.toml
+++ b/tegola/tegola.toml
@@ -86,10 +86,10 @@ name = "osm"
 attribution = 'Map data © <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
 center = [ -0.2416797, 51.5287718, 14.0 ] # London, UK
 
-#  [[maps.layers]]
-#  provider_layer = "osm.landuse"
-#  min_zoom = 7
-#  max_zoom = 14
+  [[maps.layers]]
+  provider_layer = "osm.landuse"
+  min_zoom = 7
+  max_zoom = 14
 
   [[maps.layers]]
   provider_layer = "osm.waterway"


### PR DESCRIPTION
* Updated imposm mapping file to introduce generalized (simplified)
tables for the land use layer.
* Updated the layer_landuse.sql function to take advantage of the new
generalized tables.
* Updated etl documentation around importing OSM data and SQL helper
functions.
* Added additional SQL helper functions.

closes #6