### PR TITLE
Refactor of the tranportation generialized tables

### DIFF
--- a/etl/create_indexes.sql
+++ b/etl/create_indexes.sql
@@ -5,7 +5,7 @@ BEGIN;
 	CREATE INDEX ON admin (admin_level);
 
 	-- layer_landuse (need to add generalized tables as well)
-	--CREATE INDEX ON planet_osm_polygon_landuse(landuse)
+	CREATE INDEX ON planet_osm_polygon_landuse(landuse);
 
 	-- layer_place_label
 	CREATE INDEX ON planet_osm_point (name);

--- a/etl/planet_osm_merge_line_transportation_gen.sql
+++ b/etl/planet_osm_merge_line_transportation_gen.sql
@@ -1,8 +1,7 @@
-
--- planet_osm_merge_line_transportation_gen_z14
-DROP MATERIALIZED VIEW IF EXISTS planet_osm_merge_line_transportation_gen_z14 CASCADE;
-CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z14 AS (
-  SELECT 
+-- planet_osm_merge_line_transportation_gen_z11
+DROP MATERIALIZED VIEW IF EXISTS planet_osm_merge_line_transportation_gen_z11 CASCADE;
+CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z11 AS (
+  SELECT
     format('%s_%s_%s_%s_%s_%s_%s_%s_%s_%s', tags, aeroway, access, bridge, highway, name, railway, ref, tunnel, waterway) AS id,
     NULL::bigint AS osm_id,
     tags,
@@ -15,168 +14,18 @@ CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z14 AS (
     ref,
     tunnel,
     waterway,
-    z_order,
-    way
-  FROM (
-    SELECT
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      min(z_order) AS z_order,
-      ST_LineMerge(ST_Collect(way)) AS way
-    FROM 
-      planet_osm_line
-    WHERE 
-      (
-        highway IN ('motorway', 'primary', 'primary_link', 'trunk', 'trunk_link', 'secondary', 'secondary_link','tertiary', 'tertiary_link', 'residential', 'unclassified', 'living_street', 'pedestrian', 'construction', 'motorway_link', 'service', 'track', 'driveway','path', 'cycleway', 'ski', 'steps', 'bridleway', 'footway') 
-        OR railway IN ('rail', 'monorail', 'narrow_gauge', 'subway', 'tram', 'funicular', 'light_rail', 'preserved') 
-        OR access = 'private'
-      ) AND ST_IsValid(way)
-    GROUP BY
-      tags, aeroway, access, bridge, highway, name, railway, ref, tunnel, waterway
-    ) AS transportation_union
-);
-
-CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z14 (id); -- necessary for concurrent refresh
-CREATE INDEX ON planet_osm_merge_line_transportation_gen_z14 USING gist (way);
-
--- planet_osm_merge_line_transportation_gen_z13
-CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z13 AS (
-  SELECT 
-    id,
-    osm_id,
-    tags,
-    aeroway,
-    access,
-    bridge,
-    highway,
-    name,
-    railway,
-    ref,
-    tunnel,
-    waterway,
-    z_order,
-    way
-  FROM (
-    SELECT
-      id,
-      osm_id,
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      z_order,
-      ST_Simplify(way, ZRes(11)) AS way
-    FROM 
-      planet_osm_merge_line_transportation_gen_z14
-    WHERE
-      (
-        highway IN ('motorway', 'primary', 'primary_link', 'trunk', 'trunk_link', 'secondary', 'secondary_link','tertiary', 'tertiary_link', 'residential', 'unclassified', 'living_street', 'pedestrian', 'construction', 'motorway_link') 
-        OR railway IN ('rail', 'monorail', 'narrow_gauge', 'subway', 'tram') 
-        OR access = 'private'
-      )
-    ) AS transportation_union
-);
-
-CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z13 (id); -- necessary for concurrent refresh
-CREATE INDEX ON planet_osm_merge_line_transportation_gen_z13 USING gist (way);
-
--- planet_osm_merge_line_transportation_gen_z12
-CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z12 AS (
-  SELECT
-    id,
-    osm_id,
-    tags,
-    aeroway,
-    access,
-    bridge,
-    highway,
-    name,
-    railway,
-    ref,
-    tunnel,
-    waterway,
-    z_order,
-    way
-  FROM (
-    SELECT
-      id,
-      osm_id,
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      z_order,
-      ST_Simplify(way, ZRes(10)) AS way
-    FROM 
-      planet_osm_merge_line_transportation_gen_z13
-    WHERE 
-        highway IN ('motorway', 'primary', 'primary_link', 'trunk', 'trunk_link', 'secondary', 'secondary_link','tertiary', 'tertiary_link', 'residential', 'unclassified', 'living_street', 'pedestrian', 'construction') 
-        OR railway IN ('rail', 'monorail', 'narrow_gauge', 'subway', 'tram') 
-        OR access = 'private'
-    ) AS transportation_union
-);
-
-CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z12 (id); -- necessary for concurrent refresh
-CREATE INDEX ON planet_osm_merge_line_transportation_gen_z12 USING gist (way);
-
--- planet_osm_merge_line_transportation_gen_z11
-CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z11 AS (
-  SELECT
-    id,
-    osm_id,
-    tags,
-    aeroway,
-    access,
-    bridge,
-    highway,
-    name,
-    railway,
-    ref,
-    tunnel,
-    waterway,
-    z_order,
-    way
-  FROM (
-    SELECT
-      id,
-      osm_id,
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      z_order,
-      ST_Simplify(way, ZRes(9)) AS way
-    FROM 
-      planet_osm_merge_line_transportation_gen_z12
-    WHERE 
-      highway IN ('motorway', 'primary', 'primary_link', 'trunk', 'trunk_link', 'secondary', 'secondary_link')
-    ) AS transportation_union
+    min(z_order) AS z_order,
+    ST_Simplify(
+      ST_LineMerge(ST_Collect(way)), ZRes(9)
+  ) AS way
+  FROM 
+    planet_osm_line
+  WHERE 
+    highway IN ('motorway', 'primary', 'primary_link', 'trunk', 'trunk_link', 'secondary', 'secondary_link')
+  AND 
+    ST_IsValid(way)
+  GROUP BY
+    tags, aeroway, access, bridge, highway, name, railway, ref, tunnel, waterway
 );
 
 CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z11 (id); -- necessary for concurrent refresh
@@ -185,7 +34,7 @@ CREATE INDEX ON planet_osm_merge_line_transportation_gen_z11 USING gist (way);
 -- planet_osm_merge_line_transportation_gen_z10
 CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z10 AS (
   SELECT
-    id, 
+    id,
     osm_id,
     tags,
     aeroway,
@@ -198,26 +47,9 @@ CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z10 AS (
     tunnel,
     waterway,
     z_order,
-    way
-  FROM (
-    SELECT
-      id,
-      osm_id,
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      z_order,
-      ST_Simplify(way, ZRes(8)) AS way
-    FROM 
-      planet_osm_merge_line_transportation_gen_z11
-    ) AS transportation_union
+    ST_Simplify(way, ZRes(8)) AS way
+  FROM 
+    planet_osm_merge_line_transportation_gen_z11
 );
 
 CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z10 (id); -- necessary for concurrent refresh
@@ -239,28 +71,11 @@ CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z9 AS (
     tunnel,
     waterway,
     z_order,
-    way
-  FROM (
-    SELECT
-      id,
-      osm_id,
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      z_order,
-      ST_Simplify(way, ZRes(7)) AS way
-    FROM 
-      planet_osm_merge_line_transportation_gen_z10
-    WHERE 
-      highway IN ('motorway', 'primary', 'primary_link', 'trunk', 'trunk_link')
-    ) AS transportation_union
+    ST_Simplify(way, ZRes(7)) AS way
+  FROM 
+    planet_osm_merge_line_transportation_gen_z10
+  WHERE 
+    highway IN ('motorway', 'primary', 'primary_link', 'trunk', 'trunk_link')
 );
 
 CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z9 (id); -- necessary for concurrent refresh
@@ -282,28 +97,11 @@ CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z8 AS (
     tunnel,
     waterway,
     z_order,
-    way
-  FROM (
-    SELECT
-      id,
-      osm_id,
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      z_order,
-      ST_Simplify(way, ZRes(6)) AS way
-    FROM 
-      planet_osm_merge_line_transportation_gen_z9
-    WHERE 
-      highway IN ('motorway', 'primary', 'primary_link', 'trunk', 'trunk_link')
-    ) AS transportation_union
+    ST_Simplify(way, ZRes(6)) AS way
+  FROM 
+    planet_osm_merge_line_transportation_gen_z9
+  WHERE 
+    highway IN ('motorway', 'primary', 'primary_link', 'trunk', 'trunk_link')
 );
 
 CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z8 (id); -- necessary for concurrent refresh
@@ -325,28 +123,11 @@ CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z7 AS (
     tunnel,
     waterway,
     z_order,
-    way
-  FROM (
-    SELECT
-      id,
-      osm_id,
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      z_order,
-      ST_Simplify(way, ZRes(5)) AS way
-    FROM 
-      planet_osm_merge_line_transportation_gen_z8
-    WHERE 
-      ST_Length(way) > 50
-    ) AS transportation_union
+    ST_Simplify(way, ZRes(5)) AS way
+  FROM 
+    planet_osm_merge_line_transportation_gen_z8
+  WHERE 
+    ST_Length(way) > 50
 );
 
 CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z7 (id); -- necessary for concurrent refresh
@@ -368,28 +149,11 @@ CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z6 AS (
     tunnel,
     waterway,
     z_order,
-    way
-  FROM (
-    SELECT
-      id,
-      osm_id,
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      z_order,
-      ST_Simplify(way, ZRes(4)) AS way
-    FROM 
-      planet_osm_merge_line_transportation_gen_z7
-    WHERE 
-      ST_Length(way) > 100
-    ) AS transportation_union
+    ST_Simplify(way, ZRes(4)) AS way
+  FROM 
+    planet_osm_merge_line_transportation_gen_z7
+  WHERE 
+    ST_Length(way) > 100
 );
 
 CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z6 (id); -- necessary for concurrent refresh
@@ -398,7 +162,7 @@ CREATE INDEX ON planet_osm_merge_line_transportation_gen_z6 USING gist (way);
 -- planet_osm_merge_line_transportation_gen_z5
 CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z5 AS (
   SELECT
-    id, 
+    id,
     osm_id,
     tags,
     aeroway,
@@ -411,28 +175,11 @@ CREATE MATERIALIZED VIEW planet_osm_merge_line_transportation_gen_z5 AS (
     tunnel,
     waterway,
     z_order,
-    way
-  FROM (
-    SELECT
-      id,
-      osm_id,
-      tags,
-      aeroway,
-      access,
-      bridge,
-      highway,
-      name,
-      railway,
-      ref,
-      tunnel,
-      waterway,
-      z_order,
-      ST_Simplify(way, ZRes(3)) AS way
-    FROM 
-      planet_osm_merge_line_transportation_gen_z6
-    WHERE 
-      ST_Length(way) > 500
-    ) AS transportation_union
+    ST_Simplify(way, ZRes(3)) AS way
+  FROM 
+    planet_osm_merge_line_transportation_gen_z6
+  WHERE 
+    ST_Length(way) > 500
 );
 
 CREATE UNIQUE INDEX ON planet_osm_merge_line_transportation_gen_z5 (id); -- necessary for concurrent refresh
@@ -446,9 +193,6 @@ DECLARE
     t TIMESTAMP WITH TIME ZONE := clock_timestamp();
 BEGIN
     RAISE LOG 'refreshing_osm_merge_line_transportation_gen_* tables';
-    REFRESH MATERIALIZED VIEW CONCURRENTLY planet_osm_merge_line_transportation_gen_z14;
-    REFRESH MATERIALIZED VIEW CONCURRENTLY planet_osm_merge_line_transportation_gen_z13;
-    REFRESH MATERIALIZED VIEW CONCURRENTLY planet_osm_merge_line_transportation_gen_z12;
     REFRESH MATERIALIZED VIEW CONCURRENTLY planet_osm_merge_line_transportation_gen_z11;
     REFRESH MATERIALIZED VIEW CONCURRENTLY planet_osm_merge_line_transportation_gen_z10;
     REFRESH MATERIALIZED VIEW CONCURRENTLY planet_osm_merge_line_transportation_gen_z9;

--- a/sql/functions/layer_transportation.sql
+++ b/sql/functions/layer_transportation.sql
@@ -137,7 +137,7 @@ AS $BODY$
         ELSE 'road'
       END AS "is"
     FROM 
-      planet_osm_merge_line_transportation_gen_z12
+      planet_osm_line
     WHERE 
       zoom_level = 12
     UNION ALL
@@ -153,7 +153,7 @@ AS $BODY$
         ELSE 'road'
       END AS "is"
     FROM 
-      planet_osm_merge_line_transportation_gen_z13
+      planet_osm_line
     WHERE 
       zoom_level = 13
     UNION ALL
@@ -169,7 +169,7 @@ AS $BODY$
         ELSE 'road'
       END AS "is"
     FROM 
-      planet_osm_merge_line_transportation_gen_z14
+      planet_osm_line
     WHERE 
       zoom_level >= 14
   ) AS layer_data


### PR DESCRIPTION
When applying the merge line strategy for the transportation
gen tables, we were encountering array limits on planet scale
datasets. This commit refines the strategy so it works on the
entire planet.

closes #9